### PR TITLE
無料SSL申請

### DIFF
--- a/public_html/.well-known/acme-challenge/.htaccess
+++ b/public_html/.well-known/acme-challenge/.htaccess
@@ -1,0 +1,1 @@
+Header set content-type text/plain

--- a/public_html/.well-known/acme-challenge/2fvzjPWzUcREh2foqoU2fE1aEGijHhi2tDfZXD5LLDw
+++ b/public_html/.well-known/acme-challenge/2fvzjPWzUcREh2foqoU2fE1aEGijHhi2tDfZXD5LLDw
@@ -1,0 +1,1 @@
+2fvzjPWzUcREh2foqoU2fE1aEGijHhi2tDfZXD5LLDw.NT4eWcovwDZE_mmmwKM2Gz5m52xCcK9Lg3uG2gx-Hao


### PR DESCRIPTION
printable.jp及びwww.printable.jpドメインに対する無料SSLを申請。
ただし、www.printable.jpはKagoyaサーバで有料SSLが適用されているため、実質、printable.jpのみに適用される。
printable.jpの所有者証明のトークンファイルをXserverへ設置。