### PR TITLE
ECcube：GTMタグを専用ブロックで実装

### DIFF
--- a/public_html/app/template/default/Block/tag_script.twig
+++ b/public_html/app/template/default/Block/tag_script.twig
@@ -1,0 +1,14 @@
+<!-- Google タグ マネージャー スニペット -->
+<script type="text/javascript">
+			( function( w, d, s, l, i ) {
+				w[l] = w[l] || [];
+				w[l].push( {'gtm.start': new Date().getTime(), event: 'gtm.js'} );
+				var f = d.getElementsByTagName( s )[0],
+					j = d.createElement( s ), dl = l != 'dataLayer' ? '&l=' + l : '';
+				j.async = true;
+				j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+				f.parentNode.insertBefore( j, f );
+			} )( window, document, 'script', 'dataLayer', 'GTM-K9Q9N3R' );
+			
+</script>
+<!-- (ここまで)Google タグ マネージャー スニペット -->

--- a/public_html/app/template/default/Block/tag_script_noscript.twig
+++ b/public_html/app/template/default/Block/tag_script_noscript.twig
@@ -1,0 +1,5 @@
+<!-- Google タグ マネージャー (noscript) スニペット  -->
+		<noscript>
+			<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9Q9N3R" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+		</noscript>
+		<!-- (ここまで) Google タグ マネージャー (noscript) スニペット  -->


### PR DESCRIPTION
タグ記載用のブロックを追加し、GTMタグを実装
コンテンツ管理 -> ブロック管理
-  外部サービス用タグ
- 外部サービス用タグ(noscript)
